### PR TITLE
Lazy load tool scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Then access via `https://localhost:8000` (you may need to accept the self-signed
 - Enable "Tool Calling" in settings
 - Tool modules are loaded only when this option is on to speed up initial page loads
 - Gallery, chat history, and text-to-speech modules are also lazy loaded the first time you use them
-- Location and mobile helpers only load when their toggles are enabled
+- Location services load only when enabled. Mobile CSS loads only on mobile devices, while mobile handling scripts load at startup for responsiveness
 - Markdown and syntax highlighting libraries load after the first message
 - Ask questions that require web search, image generation, or other tools
 - The AI will automatically use appropriate tools when needed

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Then access via `https://localhost:8000` (you may need to accept the self-signed
 
 #### Tool Calling
 - Enable "Tool Calling" in settings
+- Tool modules are loaded only when this option is on to speed up initial page loads
 - Ask questions that require web search, image generation, or other tools
 - The AI will automatically use appropriate tools when needed
 - Available tools include finance, food, entertainment, social media, jobs, real estate, and more

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ Then access via `https://localhost:8000` (you may need to accept the self-signed
 #### Tool Calling
 - Enable "Tool Calling" in settings
 - Tool modules are loaded only when this option is on to speed up initial page loads
+- Gallery, chat history, and text-to-speech modules are also lazy loaded the first time you use them
+- Location and mobile helpers only load when their toggles are enabled
+- Markdown and syntax highlighting libraries load after the first message
 - Ask questions that require web search, image generation, or other tools
 - The AI will automatically use appropriate tools when needed
 - Available tools include finance, food, entertainment, social media, jobs, real estate, and more

--- a/index.html
+++ b/index.html
@@ -37,8 +37,6 @@
 
   <!-- Link to modular CSS -->
   <link rel="stylesheet" href="src/css/main.css" />
-  <!-- Marked for markdown parsing -->
-  <script src="src/js/lib/marked.min.js"></script>
 
   <!-- DOMPurify for sanitizing HTML -->
   <script src="src/js/lib/purify.min.js"></script>
@@ -50,18 +48,17 @@
   <script src="src/js/utils/highlight.js"></script>
   <script src="src/js/utils/imageStorage.js"></script>
   <script src="src/js/utils/conversationStorage.js"></script>
-  <script src="src/js/utils/mobileHandling.js"></script>
   <script src="src/js/utils/notifications.js"></script>
   <script src="src/js/utils/menuSystem.js"></script>
   <script src="src/js/utils/tooltips.js"></script>
   <script src="src/js/utils/toolLoader.js"></script>
+  <script src="src/js/utils/lazyLoader.js"></script>
   <!-- Load components next -->
   <script src="src/js/components/messages.js"></script>
   <script src="src/js/components/settings.js"></script>
   <script src="src/js/components/ui.js"></script>
   <script src="src/js/components/theme.js"></script>
   <script src="src/js/components/interaction.js"></script>
-  <script src="src/js/components/gallery.js"></script>
   <script src="src/js/components/tools.js"></script>
   <script src="src/js/components/logo.js"></script>
   <!-- Load service functions -->  
@@ -69,10 +66,7 @@
   <script src="src/js/services/apiKeys.js"></script>
   <script src="src/js/services/api.js"></script>
   <script src="src/js/services/streaming.js"></script>
-  <script src="src/js/services/history.js"></script>
   <script src="src/js/services/export.js"></script>
-  <script src="src/js/services/tts.js"></script>
-  <script src="src/js/services/location.js"></script>
   
   <!-- Load initialization code -->
   <!-- Initialize global variables and state first -->

--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@
   <script src="src/js/utils/highlight.js"></script>
   <script src="src/js/utils/imageStorage.js"></script>
   <script src="src/js/utils/conversationStorage.js"></script>
+  <!-- Mobile handling must load at startup for resize listeners -->
+  <script src="src/js/utils/mobileHandling.js"></script>
   <script src="src/js/utils/notifications.js"></script>
   <script src="src/js/utils/menuSystem.js"></script>
   <script src="src/js/utils/tooltips.js"></script>

--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
   <script src="src/js/utils/notifications.js"></script>
   <script src="src/js/utils/menuSystem.js"></script>
   <script src="src/js/utils/tooltips.js"></script>
+  <script src="src/js/utils/toolLoader.js"></script>
   <!-- Load components next -->
   <script src="src/js/components/messages.js"></script>
   <script src="src/js/components/settings.js"></script>
@@ -65,16 +66,6 @@
   <script src="src/js/components/logo.js"></script>
   <!-- Load service functions -->  
   <script src="src/js/services/tools/definitions.js"></script>
-  <script src="src/js/services/tools/finance.js"></script>
-  <script src="src/js/services/tools/images.js"></script>
-  <script src="src/js/services/tools/utilities.js"></script>
-  <script src="src/js/services/tools/search.js"></script>
-  <script src="src/js/services/tools/food.js"></script>  
-  <script src="src/js/services/tools/social.js"></script>
-  <script src="src/js/services/tools/entertainment.js"></script>
-  <script src="src/js/services/tools/jobs.js"></script>
-  <script src="src/js/services/tools/realestate.js"></script>
-  <script src="src/js/services/tools/tools.js"></script>
   <script src="src/js/services/apiKeys.js"></script>
   <script src="src/js/services/api.js"></script>
   <script src="src/js/services/streaming.js"></script>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -30,7 +30,6 @@
 /* Layout Components */
 @import url('./components/layout/layout.css');
 @import url('./components/layout/messages.css');
-@import url('./components/layout/mobile.css');
 
 /* UI Components */
 @import url('./components/ui/controls.css');

--- a/src/js/components/interaction.js
+++ b/src/js/components/interaction.js
@@ -52,8 +52,10 @@ window.sendMessage = async function() {
   console.info('User message added to conversation history.');
   
   // Update browser URL
-  window.updateBrowserHistory();
-  console.info('Browser history updated.');
+  if (typeof window.updateBrowserHistory === 'function') {
+    window.updateBrowserHistory();
+    console.info('Browser history updated.');
+  }
 
   try {
     // Get API endpoint and prepare request data

--- a/src/js/init/eventListeners.js
+++ b/src/js/init/eventListeners.js
@@ -677,23 +677,31 @@ function setupTtsEventListeners() {
   // TTS settings
   if (window.ttsToggle) {
     window.ttsToggle.addEventListener('change', async (e) => {
-      window.ttsConfig.enabled = e.target.checked;
-
       if (e.target.checked) {
         if (typeof window.loadTtsModule === 'function' && !window.lazyModulesLoaded?.tts) {
           await window.loadTtsModule();
         }
+        // Ensure config exists after loading module
+        window.ttsConfig = window.ttsConfig || { enabled: false, voice: 'ash', instructions: '', autoplay: true };
+        window.ttsConfig.enabled = true;
+
         if (typeof window.initializeTts === 'function') {
           window.initializeTts();
         }
-      } else if (typeof window.stopTtsAudio === 'function') {
-        window.stopTtsAudio();
+      } else {
+        if (window.ttsConfig) {
+          window.ttsConfig.enabled = false;
+        }
+        if (typeof window.stopTtsAudio === 'function') {
+          window.stopTtsAudio();
+        }
       }
     });
   }
   
   if (window.ttsAutoplayToggle) {
     window.ttsAutoplayToggle.addEventListener('change', (e) => {
+      window.ttsConfig = window.ttsConfig || { enabled: false, voice: 'ash', instructions: '', autoplay: true };
       window.ttsConfig.autoplay = e.target.checked;
       
       // If autoplay was enabled and we have messages in queue, start playing
@@ -707,6 +715,7 @@ function setupTtsEventListeners() {
   if (window.ttsVoiceSelector) {
     window.ttsVoiceSelector.addEventListener('change', (e) => {
       // Update the TTS configuration with the new voice
+      window.ttsConfig = window.ttsConfig || { enabled: false, voice: 'ash', instructions: '', autoplay: true };
       window.ttsConfig.voice = e.target.value;
       
       // Notification is now handled in tts.js
@@ -715,11 +724,13 @@ function setupTtsEventListeners() {
   
   if (window.ttsInstructionsInput) {
     window.ttsInstructionsInput.addEventListener('change', (e) => {
+      window.ttsConfig = window.ttsConfig || { enabled: false, voice: 'ash', instructions: '', autoplay: true };
       window.ttsConfig.instructions = e.target.value;
     });
   }
-    if (window.testTtsButton) {
+  if (window.testTtsButton) {
     window.testTtsButton.addEventListener('click', () => {
+      window.ttsConfig = window.ttsConfig || { enabled: false, voice: 'ash', instructions: '', autoplay: true };
       if (!window.ttsConfig.enabled) {
         console.warn('TTS is disabled. Enable it first to test.');
         return;

--- a/src/js/init/eventListeners.js
+++ b/src/js/init/eventListeners.js
@@ -766,6 +766,10 @@ function setupToolCallingEventListeners() {
           });
         }
       }
+
+      if (e.target.checked && typeof window.loadToolScripts === 'function') {
+        window.loadToolScripts().catch(err => console.error('Failed to load tool scripts:', err));
+      }
     });
   }
 }

--- a/src/js/init/initialization.js
+++ b/src/js/init/initialization.js
@@ -145,9 +145,7 @@ function initialize() {
     // Set initial conversation name based on personality/prompt type
     initializeConversationName();
     
-    // Initialize marked (Markdown parser)
-    initializeMarked();
-    if (window.VERBOSE_LOGGING) console.info('Marked (Markdown parser) initialized.');
+
     
     // Setup event listeners
     setupEventListeners();
@@ -180,13 +178,21 @@ function initialize() {
     // Initialize services and models
     initializeServicesAndModels();
     
-    // Initialize TTS
-    window.initializeTts();
-    if (window.VERBOSE_LOGGING) console.info('TTS initialized.');
+
     
-    // Initialize mobile keyboard handling
-    window.initializeMobileKeyboardHandling();
-    if (window.VERBOSE_LOGGING) console.info('Mobile keyboard handling initialized.');
+    // Load mobile features if needed
+    if (window.isMobileDevice && window.isMobileDevice()) {
+      if (typeof window.loadMobileCss === 'function') {
+        window.loadMobileCss();
+      }
+      if (typeof window.loadMobileHandling === 'function') {
+        window.loadMobileHandling().then(() => {
+          if (typeof window.initializeMobileKeyboardHandling === 'function') {
+            window.initializeMobileKeyboardHandling();
+          }
+        }).catch(err => console.error('Failed to load mobile handling module', err));
+      }
+    }
       // Call these functions to initialize the UI
     window.updateParameterControls();
     
@@ -213,13 +219,17 @@ function initialize() {
     // Focus the user input safely (checks for mobile device)
     focusInputField();
     
-    // Pre-load highlight.js
-    window.loadHighlightJS().then(() => {
-      if (window.VERBOSE_LOGGING) console.info('Highlight.js preloaded.');
-    }).catch(err => console.error('Failed to preload highlight.js', err));    // Initialize tool calling toggle state
+    // Initialize tool calling toggle state
     initializeToolCalling();
-      // Initialize location service
-    initializeLocationService();
+
+    // Load location services if previously enabled
+    if (localStorage.getItem('locationEnabled') === 'true' && typeof window.loadLocationModule === 'function') {
+      window.loadLocationModule().then(() => {
+        if (typeof window.initializeLocationService === 'function') {
+          window.initializeLocationService();
+        }
+      }).catch(err => console.error('Failed to load location module', err));
+    }
     
     // Check if API keys are missing and auto-open the API keys tab if needed
     if (typeof window.openApiKeysTabIfNeeded === 'function') {

--- a/src/js/init/initialization.js
+++ b/src/js/init/initialization.js
@@ -180,17 +180,13 @@ function initialize() {
     
 
     
-    // Load mobile features if needed
+    // Mobile handling now loads at startup so just run initialization on mobile
     if (window.isMobileDevice && window.isMobileDevice()) {
       if (typeof window.loadMobileCss === 'function') {
         window.loadMobileCss();
       }
-      if (typeof window.loadMobileHandling === 'function') {
-        window.loadMobileHandling().then(() => {
-          if (typeof window.initializeMobileKeyboardHandling === 'function') {
-            window.initializeMobileKeyboardHandling();
-          }
-        }).catch(err => console.error('Failed to load mobile handling module', err));
+      if (typeof window.initializeMobileKeyboardHandling === 'function') {
+        window.initializeMobileKeyboardHandling();
       }
     }
       // Call these functions to initialize the UI

--- a/src/js/init/services.js
+++ b/src/js/init/services.js
@@ -92,10 +92,15 @@ function initializeToolCalling() {
     }
     window.toolCallingToggle.checked = enabled;
     window.config.enableFunctionCalling = enabled;
-    
+
     // Make sure to apply the master toggle state to individual tool toggles
     if (typeof window.updateMasterToolCallingStatus === 'function') {
       window.updateMasterToolCallingStatus(enabled);
+    }
+
+    // Load tool scripts on first initialization if enabled
+    if (enabled && typeof window.loadToolScripts === 'function') {
+      window.loadToolScripts().catch(err => console.error('Failed to load tool scripts:', err));
     }
   }
 }

--- a/src/js/services/streaming.js
+++ b/src/js/services/streaming.js
@@ -340,7 +340,12 @@ window.processMainContentMarkdown = function(mainText) {
         html += '`';
     }
       // First parse the markdown content
-    let parsedContent = window.sanitizeWithYouTube ? window.sanitizeWithYouTube(marked.parse(html)) : DOMPurify.sanitize(marked.parse(html));
+    if (typeof marked === 'undefined' && typeof window.loadMarkedLibrary === 'function') {
+        window.loadMarkedLibrary();
+    }
+    let parsedContent = typeof marked !== 'undefined'
+        ? (window.sanitizeWithYouTube ? window.sanitizeWithYouTube(marked.parse(html)) : DOMPurify.sanitize(marked.parse(html)))
+        : DOMPurify.sanitize(html);
     
     // Then wrap image placeholders with span elements so they can be hidden with CSS
     // This ensures the markdown parser doesn't interfere with our spans

--- a/src/js/utils/lazyLoader.js
+++ b/src/js/utils/lazyLoader.js
@@ -1,0 +1,61 @@
+/**
+ * Lazy loading utilities for optional modules to reduce initial page weight.
+ */
+
+window.lazyModulesLoaded = window.lazyModulesLoaded || {};
+
+function loadScriptOnce(src, flag) {
+  return new Promise((resolve, reject) => {
+    if (window.lazyModulesLoaded[flag]) return resolve();
+    const script = document.createElement('script');
+    script.src = src;
+    script.onload = () => {
+      window.lazyModulesLoaded[flag] = true;
+      resolve();
+    };
+    script.onerror = err => reject(err);
+    document.head.appendChild(script);
+  });
+}
+
+window.loadGalleryModule = function() {
+  return loadScriptOnce('/src/js/components/gallery.js', 'gallery');
+};
+
+window.loadHistoryModule = function() {
+  return loadScriptOnce('/src/js/services/history.js', 'history');
+};
+
+window.loadTtsModule = function() {
+  return loadScriptOnce('/src/js/services/tts.js', 'tts');
+};
+
+window.loadLocationModule = function() {
+  return loadScriptOnce('/src/js/services/location.js', 'location');
+};
+
+window.isMobileDevice = function() {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) ||
+         window.innerWidth <= 768;
+};
+
+window.loadMobileHandling = function() {
+  return loadScriptOnce('/src/js/utils/mobileHandling.js', 'mobileHandling');
+};
+
+window.loadMobileCss = function() {
+  if (window.lazyModulesLoaded.mobileCss) return;
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'src/css/components/layout/mobile.css';
+  document.head.appendChild(link);
+  window.lazyModulesLoaded.mobileCss = true;
+};
+
+window.loadMarkedLibrary = function() {
+  return loadScriptOnce('/src/js/lib/marked.min.js', 'marked').then(() => {
+    if (typeof window.initializeMarked === 'function') {
+      window.initializeMarked();
+    }
+  });
+};

--- a/src/js/utils/toolLoader.js
+++ b/src/js/utils/toolLoader.js
@@ -1,0 +1,49 @@
+/**
+ * Dynamically load tool implementation scripts on demand
+ */
+
+window.toolScriptsLoaded = false;
+
+window.loadToolScripts = function() {
+  if (window.toolScriptsLoaded) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const scriptPaths = [
+      '/src/js/services/tools/finance.js',
+      '/src/js/services/tools/images.js',
+      '/src/js/services/tools/utilities.js',
+      '/src/js/services/tools/search.js',
+      '/src/js/services/tools/food.js',
+      '/src/js/services/tools/social.js',
+      '/src/js/services/tools/entertainment.js',
+      '/src/js/services/tools/jobs.js',
+      '/src/js/services/tools/realestate.js',
+      '/src/js/services/tools/tools.js'
+    ];
+
+    let loaded = 0;
+
+    const onLoad = () => {
+      loaded += 1;
+      if (loaded === scriptPaths.length) {
+        window.toolScriptsLoaded = true;
+        resolve();
+      }
+    };
+
+    const onError = (err) => {
+      console.error('Failed to load tool script:', err);
+      reject(err);
+    };
+
+    scriptPaths.forEach(src => {
+      const script = document.createElement('script');
+      script.src = src;
+      script.onload = onLoad;
+      script.onerror = onError;
+      document.head.appendChild(script);
+    });
+  });
+};


### PR DESCRIPTION
## Summary
- add lazy loader for tool implementations
- only load tool scripts when tool calling is enabled
- insert loader into initialization and event listeners
- document lazy loading in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860d1f106488327b2a2f9cf2ec15253