### PR TITLE
Add image upload attachments

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,11 @@
           aria-label="User input"
         ></textarea>
         <button id="upload-button" title="Attach image">
-          <img src="src/assets/img/upload.svg" alt="Upload" width="20" height="20" />
+          <svg class="upload-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M4 17v2a1 1 0 001 1h14a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <polyline points="7 9 12 4 17 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            <line x1="12" y1="4" x2="12" y2="16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
         </button>
         <input type="file" id="image-upload" accept="image/*" multiple style="display:none" />
         <button id="send-button" title="Send message">

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
   <script src="src/js/components/ui.js"></script>
   <script src="src/js/components/theme.js"></script>
   <script src="src/js/components/interaction.js"></script>
+  <script src="src/js/components/attachments.js"></script>
   <script src="src/js/components/tools.js"></script>
   <script src="src/js/components/logo.js"></script>
   <!-- Load service functions -->  
@@ -160,12 +161,17 @@
 
     <div class="input-container">
       <div class="input-wrapper">
+        <div class="upload-previews"></div>
         <textarea
           id="user-input"
           placeholder="Type your message here..."
           rows="1"
           aria-label="User input"
         ></textarea>
+        <button id="upload-button" title="Attach image">
+          <img src="src/assets/img/upload.svg" alt="Upload" width="20" height="20" />
+        </button>
+        <input type="file" id="image-upload" accept="image/*" multiple style="display:none" />
         <button id="send-button" title="Send message">
           <svg class="send-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
             <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>

--- a/src/assets/img/upload.svg
+++ b/src/assets/img/upload.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M4 17v2a1 1 0 001 1h14a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <polyline points="7 9 12 4 17 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="12" y1="4" x2="12" y2="16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/img/upload.svg
+++ b/src/assets/img/upload.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-  <path d="M4 17v2a1 1 0 001 1h14a1 1 0 001-1v-2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <polyline points="7 9 12 4 17 9" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-  <line x1="12" y1="4" x2="12" y2="16" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/src/css/components/layout/messages.css
+++ b/src/css/components/layout/messages.css
@@ -9,7 +9,7 @@
 }
 
 .message-content {
-  padding: 20px 16px 0px 16px;
+  padding: 20px 16px;
   border-radius: 12px;
   color: var(--text-primary);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);

--- a/src/css/components/ui/controls.css
+++ b/src/css/components/ui/controls.css
@@ -298,5 +298,40 @@ input:focus + .toggle-switch {
   to { transform: rotate(360deg); }
 }
 
+/* Upload button */
+#upload-button {
+  position: absolute;
+  right: 58px;
+  top: 48%;
+  transform: translateY(-50%);
+  background: transparent;
+  color: var(--accent-color);
+  border: none;
+  border-radius: 6px;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 2;
+  margin: 0;
+  padding: 0;
+}
+
+.upload-previews {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.upload-preview-img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+
 
 

--- a/src/css/components/ui/controls.css
+++ b/src/css/components/ui/controls.css
@@ -300,7 +300,7 @@ input:focus + .toggle-switch {
 /* Upload button */
 #upload-button {
   position: absolute;
-  right: 58px;
+  right: 55px;
   bottom: 5px;
   background: transparent;
   color: var(--accent-color);

--- a/src/css/components/ui/controls.css
+++ b/src/css/components/ui/controls.css
@@ -39,8 +39,7 @@
 #send-button {
   position: absolute;
   right: 5px;
-  top: 48%;
-  transform: translateY(-50%);
+  bottom: 5px;
   background: transparent;
   color: var(--accent-color);
   border: none;
@@ -117,7 +116,7 @@
 /* Hover effects removed */
 
 #send-button:active {
-  transform: translateY(-50%) scale(0.95);
+  transform: scale(0.95);
 }
 
 /* Settings button */
@@ -302,8 +301,7 @@ input:focus + .toggle-switch {
 #upload-button {
   position: absolute;
   right: 58px;
-  top: 48%;
-  transform: translateY(-50%);
+  bottom: 5px;
   background: transparent;
   color: var(--accent-color);
   border: none;
@@ -318,6 +316,10 @@ input:focus + .toggle-switch {
   z-index: 2;
   margin: 0;
   padding: 0;
+}
+
+#upload-button:active {
+  transform: scale(0.95);
 }
 
 .upload-previews {

--- a/src/js/components/attachments.js
+++ b/src/js/components/attachments.js
@@ -1,0 +1,56 @@
+/**
+ * Image upload and attachment handling
+ */
+
+window.pendingUploads = [];
+
+window.initImageUploads = function() {
+  const uploadInput = document.getElementById('image-upload');
+  const uploadButton = document.getElementById('upload-button');
+  if (!uploadInput || !uploadButton) return;
+
+  uploadButton.addEventListener('click', () => uploadInput.click());
+  uploadInput.addEventListener('change', async (e) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length === 0) return;
+    window.pendingUploads = [];
+    for (const file of files) {
+      if (!file.type.startsWith('image/')) continue;
+      const dataUrl = await readFileAsDataURL(file);
+      window.pendingUploads.push({ file, dataUrl });
+    }
+    if (typeof window.showPendingUploadPreviews === 'function') {
+      window.showPendingUploadPreviews();
+    }
+    uploadInput.value = '';
+  });
+};
+
+function readFileAsDataURL(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+window.showPendingUploadPreviews = function() {
+  const wrapper = document.querySelector('.input-wrapper');
+  if (!wrapper) return;
+  let preview = wrapper.querySelector('.upload-previews');
+  if (!preview) {
+    preview = document.createElement('div');
+    preview.className = 'upload-previews';
+    wrapper.insertBefore(preview, wrapper.firstChild);
+  }
+  preview.innerHTML = '';
+  window.pendingUploads.forEach(up => {
+    const img = document.createElement('img');
+    img.src = up.dataUrl;
+    img.alt = 'Upload preview';
+    img.className = 'upload-preview-img';
+    preview.appendChild(img);
+  });
+};
+

--- a/src/js/components/gallery.js
+++ b/src/js/components/gallery.js
@@ -118,21 +118,22 @@ window.loadGalleryImages = async function() {
     try {
         // Get all image keys from IndexedDB
         const images = await window.getAllImagesFromDb();
-        
-        if (!images || images.length === 0) {
+        const visibleImages = images.filter(img => !img.filename.startsWith('upload-'));
+
+        if (!visibleImages || visibleImages.length === 0) {
             galleryGrid.innerHTML = '<div class="gallery-empty">No images found in gallery</div>';
             return;
         }
         
         // Sort images by timestamp, newest first
-        images.sort((a, b) => {
+        visibleImages.sort((a, b) => {
             const dateA = a.timestamp ? new Date(a.timestamp) : new Date(0);
             const dateB = b.timestamp ? new Date(b.timestamp) : new Date(0);
             return dateB - dateA;
         });
-        
+
         // Store images globally for slideshow access
-        window.galleryImages = images;
+        window.galleryImages = visibleImages;
         window.galleryImagesLoaded = true;
         
         // Clear placeholders
@@ -141,17 +142,17 @@ window.loadGalleryImages = async function() {
         // Update gallery count
         const galleryCount = document.getElementById('gallery-count');
         if (galleryCount) {
-            galleryCount.textContent = images.length;
+            galleryCount.textContent = visibleImages.length;
         }
         
         // Process images in batches to not block the UI
         const batchSize = 10;
         
         function processBatch(startIndex) {
-            const endIndex = Math.min(startIndex + batchSize, images.length);
-            
+            const endIndex = Math.min(startIndex + batchSize, visibleImages.length);
+
             for (let i = startIndex; i < endIndex; i++) {
-                const image = images[i];
+                const image = visibleImages[i];
                 
                 // Create gallery item
                 const galleryItem = document.createElement('div');
@@ -266,7 +267,7 @@ window.loadGalleryImages = async function() {
             }
             
             // Process next batch if needed
-            if (endIndex < images.length) {
+            if (endIndex < visibleImages.length) {
                 setTimeout(() => processBatch(endIndex), 0);
             }
         }

--- a/src/js/init/initialization.js
+++ b/src/js/init/initialization.js
@@ -120,6 +120,10 @@ async function initialize() {
     // Initialize DOM references first
     initializeDOMReferences();
     if (window.VERBOSE_LOGGING) console.info('DOM references initialized.');
+
+    if (typeof window.initImageUploads === 'function') {
+      window.initImageUploads();
+    }
     
     // Initialize textarea height to prevent shrinking when typing
     initializeTextareaHeight();

--- a/src/js/services/history.js
+++ b/src/js/services/history.js
@@ -790,7 +790,8 @@ function renderConversationMessages(convo, imageCache) {
       return;
     }
     if (msg.role === 'user') {
-      window.appendMessage('You', msg.content, 'user', true);
+      const processed = replaceImagePlaceholders(msg.content, convo, imageCache);
+      window.appendMessage('You', processed, 'user', true);
     } else if (msg.role === 'assistant') {
       const messageElement = document.createElement('div');
       messageElement.classList.add('message', 'assistant');


### PR DESCRIPTION
## Summary
- enable image attachments with new upload button
- preview uploads in chat input
- store uploads in IndexedDB using unique `upload-` filename prefix
- hide uploaded images from gallery view
- create SVG upload icon and styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864209e01208327b2cbf9dffdbb11a9