### PR TITLE
Add vision support for image attachments

### DIFF
--- a/src/js/components/interaction.js
+++ b/src/js/components/interaction.js
@@ -110,7 +110,7 @@ window.sendMessage = async function() {
   try {
     // Get API endpoint and prepare request data
     const apiEndpoint = window.getApiEndpoint();
-    const { requestBody, headers } = window.prepareRequestData(message);
+    const { requestBody, headers } = window.prepareRequestData(message, uploads);
 
     // Ensure an API key is configured before proceeding (except for Ollama)
     const currentService = window.config.defaultService;
@@ -218,6 +218,9 @@ window.sendMessage = async function() {
   } finally {
     // Reset UI state
     window.resetSendButton();
+    if (uploads.length > 0 && typeof window.stripBase64FromHistory === 'function') {
+      window.stripBase64FromHistory(userId, placeholders);
+    }
     if (window.VERBOSE_LOGGING) console.info('Send button reset.');
   }
 };

--- a/src/js/services/api.js
+++ b/src/js/services/api.js
@@ -61,9 +61,26 @@ window.cleanMessagesForApi = function(messages) {
   return messages.map(msg => {
     if (msg.role === 'user' || msg.role === 'assistant') {
       let content = msg.content || '';
-      // Remove thinking tags
-      content = content.replace(/<think>[\s\S]*?<\/think>/g, '');
-      content = content.replace(/<\|begin_of_thought\|>[\s\S]*?<\|end_of_thought\|>/g, '');
+      
+      // Handle different content formats
+      if (typeof content === 'string') {
+        // Remove thinking tags from string content
+        content = content.replace(/<think>[\s\S]*?<\/think>/g, '');
+        content = content.replace(/<\|begin_of_thought\|>[\s\S]*?<\|end_of_thought\|>/g, '');
+      } else if (Array.isArray(content)) {
+        // Handle multimodal content (array of objects)
+        content = content.map(part => {
+          if (part.type === 'text' && typeof part.text === 'string') {
+            return {
+              ...part,
+              text: part.text
+                .replace(/<think>[\s\S]*?<\/think>/g, '')
+                .replace(/<\|begin_of_thought\|>[\s\S]*?<\|end_of_thought\|>/g, '')
+            };
+          }
+          return part; // Return non-text parts unchanged
+        });
+      }
       
       // Return only standard OpenAI Chat Completions API fields
       const cleanedMsg = {
@@ -79,15 +96,31 @@ window.cleanMessagesForApi = function(messages) {
       return cleanedMsg;
     } else if (msg.role === 'system' || msg.role === 'developer') {
       // System/developer messages should only have role and content
+      // Ensure content is a string for these message types
+      let content = msg.content || '';
+      if (typeof content !== 'string') {
+        // If content is not a string, try to extract text from it
+        if (Array.isArray(content)) {
+          const textParts = content.filter(part => part.type === 'text').map(part => part.text || '');
+          content = textParts.join(' ');
+        } else {
+          content = String(content);
+        }
+      }
       return {
         role: msg.role,
-        content: msg.content || ''
+        content: content
       };
     } else if (msg.role === 'tool') {
       // Tool messages need role, content, and tool_call_id
+      // Ensure content is a string for tool messages
+      let content = msg.content || '';
+      if (typeof content !== 'string') {
+        content = String(content);
+      }
       return {
         role: msg.role,
-        content: msg.content || '',
+        content: content,
         tool_call_id: msg.tool_call_id
       };
     }

--- a/src/js/utils/utils.js
+++ b/src/js/utils/utils.js
@@ -277,3 +277,21 @@ window.debugThinkingContainers = function() {
     console.log(`Thinking container ${index} (${container.id}): ${isCollapsed ? 'collapsed' : 'expanded'}`);
   });
 };
+
+/**
+ * Replace base64 image data URLs in a user message with filename placeholders.
+ * This prevents large base64 strings from being stored in conversation history.
+ * @param {string} messageId - ID of the user message
+ * @param {Array} placeholders - Array of placeholder strings like '[[IMAGE: file.jpg]]'
+ */
+window.stripBase64FromHistory = function(messageId, placeholders = []) {
+  if (!Array.isArray(window.conversationHistory)) return;
+  const entry = window.conversationHistory.find(msg => msg.id === messageId);
+  if (!entry || entry.role !== 'user') return;
+
+  let textPart = entry.content || '';
+  // Remove any base64 image data
+  textPart = textPart.replace(/data:image\/[^;]+;base64,[^\s]+/g, '').trim();
+  const placeholderText = placeholders.join('\n');
+  entry.content = placeholderText + (textPart ? `\n\n${textPart}` : '');
+};


### PR DESCRIPTION
## Summary
- allow `sendMessage` to pass pending uploads to `prepareRequestData`
- extend `prepareRequestData` so that any attached images are added to the chat completions request
- replace base64 image data with placeholders in conversation history once response is processed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686441ea15788327a37237cd8ae1c8c9