### PR TITLE
Fix duplication bug for non-vision models

### DIFF
--- a/src/js/services/api.js
+++ b/src/js/services/api.js
@@ -253,7 +253,7 @@ window.prepareRequestData = function(message, uploads = [], shouldExcludeImages 
       .filter(msg => msg.role !== 'system' && msg.role !== 'developer')
       .slice(-(maxContext * 2));
 
-    if (uploads.length > 0 && rawMessages.length > 0 && rawMessages[rawMessages.length - 1].role === 'user') {
+    if (uploads.length > 0 && !shouldExcludeImages && rawMessages.length > 0 && rawMessages[rawMessages.length - 1].role === 'user') {
       rawMessages.pop(); // replace with image-based message below
     }
     


### PR DESCRIPTION
## Summary
- avoid popping the last message when images are excluded from the API call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864af4d777c83278e49e0b9e7704097