### PR TITLE
Add Meta AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Overview
 
-Tyumi is a powerful, client-side AI chatbot web application that seamlessly integrates with multiple AI providers including OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, GitHub Models, and local Ollama models. Built with a modular architecture, it offers advanced features like personality customization, tool calling, text-to-speech, theme customization, and secure local storage.
+Tyumi is a powerful, client-side AI chatbot web application that seamlessly integrates with multiple AI providers including OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, Meta AI, GitHub Models, and local Ollama models. Built with a modular architecture, it offers advanced features like personality customization, tool calling, text-to-speech, theme customization, and secure local storage.
 
 ## 🌟 Key Features
     
@@ -25,6 +25,7 @@ Tyumi is a powerful, client-side AI chatbot web application that seamlessly inte
 - **Mistral** (Mistral, Codestral, etc)
 - **xAI** (Grok models)
 - **Hugging Face** (open-source models like DeepSeek-R1, Llama4, Qwen3)
+- **Meta AI** (Llama models via Meta API)
 - **GitHub Models** (unified access to OpenAI, Meta, Microsoft, Mistral models)
 - **Ollama** (local open-source models)
 

--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@
   <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=no" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https: http://localhost:* ws://localhost:* wss://localhost:*; img-src 'self' data: https: blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; frame-src 'self' https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com; media-src 'self' data: blob: https:; child-src 'self' https://www.youtube.com https://youtube.com https://www.youtube-nocookie.com;">
   <title>Tyumi</title>
-  <meta name="description" content="An open source AI assistant platform that integrates with multiple AI providers including OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, GitHub Models, and local Ollama models." />
+  <meta name="description" content="An open source AI assistant platform that integrates with multiple AI providers including OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, Meta AI, GitHub Models, and local Ollama models." />
 
   <!-- Additional Meta Tags -->
   <meta name="author" content="Dustin Whyte">
-  <meta name="keywords" content="AI assistant, Tyumi, AI chatbot, open source AI, OpenAI, Anthropic, Claude, Google Gemini, Mistral, xAI, Grok, Hugging Face, GitHub Models, Ollama, local AI models, chatbot platform, conversational AI, generative AI, large language model, AI integration, AI web app, AI privacy, AI security, AI productivity, AI tools, AI platform, artificial intelligence" />
+  <meta name="keywords" content="AI assistant, Tyumi, AI chatbot, open source AI, OpenAI, Anthropic, Claude, Google Gemini, Mistral, xAI, Grok, Hugging Face, Meta AI, GitHub Models, Ollama, local AI models, chatbot platform, conversational AI, generative AI, large language model, AI integration, AI web app, AI privacy, AI security, AI productivity, AI tools, AI platform, artificial intelligence" />
   <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">
   <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">
   <meta name="application-name" content="Tyumi">
@@ -16,7 +16,7 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://tyumi.app/">
   <meta property="og:title" content="Tyumi - Open Source AI Assistant Platform">
-  <meta property="og:description" content="An open source AI assistant platform integrating with OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, GitHub Models and local Ollama models.">
+  <meta property="og:description" content="An open source AI assistant platform integrating with OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, Meta AI, GitHub Models and local Ollama models.">
   <meta property="og:image" content="https://tyumi.app/logo.jpg">
   <meta property="og:site_name" content="Tyumi">
 
@@ -24,7 +24,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://tyumi.app/">
   <meta name="twitter:title" content="Tyumi - Open Source AI Assistant Platform">
-  <meta name="twitter:description" content="An open source AI assistant platform integrating with OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, GitHub Models and local Ollama models.">
+  <meta name="twitter:description" content="An open source AI assistant platform integrating with OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, Meta AI, GitHub Models and local Ollama models.">
   <meta name="twitter:image" content="https://tyumi.app/logo.jpg">
 
   <!-- Mobile Web App -->

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -216,6 +216,22 @@ window.config = {
             ],
             defaultModel: 'Qwen/Qwen3-30B-A3B',
         },
+
+        // Meta AI API
+        meta: {
+            baseUrl: 'https://api.llama.com/v1',
+            apiKey: '',
+            models: [
+                'Llama-4-Maverick-17B-128E-Instruct-FP8',
+                'Llama-4-Scout-17B-16E-Instruct-FP8',
+                'Llama-3.3-70B-Instruct',
+                'Llama-3.3-8B-Instruct',
+                'Cerebras-Llama-4-Maverick-17B-128E-Instruct',
+                'Cerebras-Llama-4-Scout-17B-16E-Instruct',
+                'Groq-Llama-4-Maverick-17B-128E-Instruct'
+            ],
+            defaultModel: 'Llama-4-Maverick-17B-128E-Instruct-FP8',
+        },
         
         // GitHub Models
         github: {

--- a/src/html/help-guide.html
+++ b/src/html/help-guide.html
@@ -116,6 +116,17 @@
           </div>
 
           <div class="api-key-guide">
+            <h4>Meta AI API Key</h4>
+            <ol>
+              <li>Visit the <a href="https://ai.meta.com/llama/" target="_blank" rel="noopener">Meta AI Llama page</a></li>
+              <li>Sign in with your Meta account</li>
+              <li>Create or view your API key</li>
+              <li>Copy the API key and paste it into Tyumi's settings</li>
+            </ol>
+            <p><strong>Note:</strong> Meta provides access to Llama models with different capabilities. Check their documentation for the latest details.</p>
+          </div>
+
+          <div class="api-key-guide">
             <h4>GitHub Models API Key</h4>
             <ol>
               <li>Visit the <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener">GitHub Personal Access Tokens page</a></li>
@@ -169,6 +180,7 @@
           <li><strong>Mistral:</strong> Fast, efficient European AI models</li>
           <li><strong>xAI:</strong> Grok models with real-time information from X and the web</li>
           <li><strong>Hugging Face:</strong> Access to open-source models like DeepSeek-V3, DeepSeek-R1, and Llama-4 variants</li>
+          <li><strong>Meta AI:</strong> Official Llama models served by Meta</li>
           <li><strong>GitHub Models:</strong> Unified access to models from multiple providers (OpenAI, Meta, Microsoft, Mistral, etc.)</li>
           <li><strong>Ollama:</strong> Run open-source models locally</li>
         </ul>

--- a/src/html/panels.html
+++ b/src/html/panels.html
@@ -346,6 +346,20 @@
         </div>
 
         <div class="setting-item">
+          <label for="meta-api-key">Meta AI API Key</label>
+          <div class="api-key-input-container">
+            <input type="password" id="meta-api-key" placeholder="Enter your Meta AI API key" aria-label="Meta AI API Key" />
+            <button class="toggle-password" data-for="meta-api-key" title="Show/Hide API Key">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                <circle cx="12" cy="12" r="3"></circle>
+              </svg>
+            </button>
+          </div>
+          <p class="info-text">Required for Llama models. <a href="https://ai.meta.com/llama/" target="_blank">Get API Key</a></p>
+        </div>
+
+        <div class="setting-item">
           <label for="github-api-key">GitHub Models API Key</label>
           <div class="api-key-input-container">
             <input type="password" id="github-api-key" placeholder="Enter your GitHub API key" aria-label="GitHub Models API Key" />
@@ -485,7 +499,7 @@
         <h3>About Tyumi</h3>
         <div class="about-content">
           <p>Version <span id="app-version"></span></p>
-          <p>Tyumi is an open source AI assistant platform that seamlessly integrates with multiple AI providers including OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, GitHub Models, and local Ollama models. It offers advanced features like personality customization, tool calling (web search, image generation, etc.), text-to-speech, theme customization, and secure local storage of conversations and API keys.</p>
+          <p>Tyumi is an open source AI assistant platform that seamlessly integrates with multiple AI providers including OpenAI, Anthropic, Google, Mistral, xAI, Hugging Face, Meta AI, GitHub Models, and local Ollama models. It offers advanced features like personality customization, tool calling (web search, image generation, etc.), text-to-speech, theme customization, and secure local storage of conversations and API keys.</p>
           <p>All of your conversations and generated images are stored locally in your browser. You can easily manage your chat history and view your images in the image gallery. Make sure to download the images you want to keep, as they are not stored on any server and will be lost if you clear your browser data.</p>
           <p>For more information, visit the <a href="https://github.com/h1ddenpr0cess20/Tyumi" target="_blank" rel="noopener">GitHub Repository</a>.</p>
           

--- a/src/js/components/settings.js
+++ b/src/js/components/settings.js
@@ -231,6 +231,9 @@ window.populateServiceSelector = function() {
       case 'huggingface':
         displayName = 'Hugging Face';
         break;
+      case 'meta':
+        displayName = 'Meta AI';
+        break;
       case 'github':
         displayName = 'GitHub Models';
         break;

--- a/src/js/services/apiKeys.js
+++ b/src/js/services/apiKeys.js
@@ -18,6 +18,7 @@ window.apiKeyInputs = {
     google: null,
     mistral: null,
     huggingface: null,
+    meta: null,
     github: null
 };
 
@@ -43,6 +44,7 @@ window.initApiKeys = function() {
     window.apiKeyInputs.google = document.getElementById('google-api-key');
     window.apiKeyInputs.mistral = document.getElementById('mistral-api-key');
     window.apiKeyInputs.huggingface = document.getElementById('huggingface-api-key');
+    window.apiKeyInputs.meta = document.getElementById('meta-api-key');
     window.apiKeyInputs.github = document.getElementById('github-api-key');      // Get DOM references for tool-specific API keys
     window.toolApiKeyInputs.rapidapi = document.getElementById('tool-rapidapi-key');
     // window.toolApiKeyInputs.alphavantage = document.getElementById('tool-alphavantage-key'); // Disabled


### PR DESCRIPTION
## Summary
- add Meta AI config
- allow entering Meta API key in settings
- show Meta AI option in service selector
- document Meta API key setup in help guide
- mention Meta in description and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68818d854a588327ae800499df1e343d